### PR TITLE
Fix several problems:

### DIFF
--- a/client.py
+++ b/client.py
@@ -1,48 +1,27 @@
 import asyncio
-import pickle
 
 class SimpleClient:
     def __init__(self):
-        self.token = ''
-
         self.reader = None
         self.writer = None
 
-        self.run = True
-    
     async def connect(self, sock):
         self.reader, self.writer = await asyncio.open_unix_connection(sock)
+        # self.reader, self.writer = await asyncio.open_connection(*sock)
 
     async def send(self, data):
-        if self.writer:
-            binary = pickle.dumps(data)
-            self.writer.write(binary)
+        binary = data.encode()
+        self.writer.write(binary)
+        await self.writer.drain()
 
     async def receive(self, size=1024):
-        ret = None
+        binary = await self.reader.read(size)
+        if not binary:
+            return None
+        return binary.decode()
 
-        if self.reader:
-            tmp = await self.reader.read(size)
-            ret = pickle.loads(tmp)
-
-        return ret
+    async def close(self):
+        self.writer.close()
+        await self.writer.wait_closed()
 
 
-
-async def main():
-    run = 0
-
-    client = SimpleClient()
-    await client.connect('./server.sock')
-
-    for i in range(10):
-        await client.send(f'hello {i}')
-        data = await client.receive()
-        print(f'received: {data}')
-        await asyncio.sleep(.1)
-        i += 1
-
-    await client.disconnect()
-
-if __name__ == '__main__':
-    asyncio.run(main())

--- a/conftest.py
+++ b/conftest.py
@@ -2,23 +2,22 @@ import pytest
 import asyncio
 from client import SimpleClient
 
-def pytest_configure(config):
-    pytest.client = None
-
-def pytest_sessionstart(session):
-    pass
-
-
-def pytest_sessionfinish(session):
-    pass
-    # if pytest.client:
-    #     pytest.client.close()
 
 @pytest.fixture(scope='session')
-async def client(request):
+async def client():
     print('client init')
     client = SimpleClient()
     print('connecting')
-    await client.connect('./server.sock')
+    # await client.connect('./server.sock')
+    await client.connect(('127.0.0.1',5062))
     print('connected, yielding')
     yield client
+    await client.close()
+
+
+@pytest.fixture(scope="session")
+def event_loop():
+    """Change event_loop fixture to module level."""
+    loop = asyncio.get_event_loop_policy().new_event_loop()
+    yield loop
+    loop.close()

--- a/server.py
+++ b/server.py
@@ -1,61 +1,50 @@
 import asyncio
-import pickle
+
 
 class SimpleServer:
     def __init__(self, reader, writer):
-        self.token = ''
-
         self.reader = reader
         self.writer = writer
 
-        self.run = True
-
     async def client_handler(self):
-        print('client_handler')
         count = 0
-        while self.run and count < 10:
-            print('receiving')
+        while True:
+            print(f'receiving {count}')
             data= await self.receive()
-            print(f"data: {data}")
-            if data:
-                print('client_handler', data)
-                await self.send(f'{data} returned')
-                count += 1
-            else:
-                print('await 0.1')
-                await asyncio.sleep(.1)
+            if not data:
+                break
+            await self.send(f'{data} returned')
+            count += 1
 
     async def send(self, data):
-        if self.writer:
-            binary = pickle.dumps(data)
-            print(binary)
-            self.writer.write(binary)
-            print('sent')
+        binary = data.encode()
+        self.writer.write(binary)
+        await self.writer.drain()
+        print(f'{binary} sent')
 
     async def receive(self, size=1024):
-        ret = None
+        binary = await self.reader.read(size)
+        if not binary:
+            return None
+        return binary.decode()
 
-        if self.reader:
-            tmp = await self.reader.read(size)
-            ret = pickle.loads(tmp)
+    async def close(self):
+        self.writer.close()
+        await self.writer.wait_closed()
 
-        return ret
 
 async def handle_client(reader, writer):
     print('handle_client')
     server = SimpleServer(reader, writer)
     await server.client_handler()
+    print('end of handle_client')
 
 
 async def main():
     server = await asyncio.start_unix_server(handle_client, './server.sock')
+    # server = await asyncio.start_server(handle_client, '127.0.0.1', 5062)
+    print("server waiting client connection")
     await server.serve_forever()
-
-    try:
-        server.serve_forever()
-    except KeyboardInterrupt:
-        pass
-    server.close()
 
 
 if __name__ == '__main__':

--- a/test_1.py
+++ b/test_1.py
@@ -1,24 +1,28 @@
 import pytest
 import asyncio
 
-@pytest.mark.usefixtures('client')
 @pytest.mark.asyncio
 async def test_1(client):
     for i in range(10):
         await client.send(f'hello {i}')
         data = await client.receive()
+        if not data:
+            print('connection closed')
+            break
         print(f'received: {data}')
         await asyncio.sleep(.1)
         i += 1
     assert True
     print('hello world')
 
-@pytest.mark.usefixtures('client')
 @pytest.mark.asyncio
 async def test_2(client):
     for i in range(10):
         await client.send(f'hello {i}')
         data = await client.receive()
+        if not data:
+            print('connection closed')
+            break
         print(f'received: {data}')
         await asyncio.sleep(.1)
         i += 1


### PR DESCRIPTION
1) As your fixture is session scoped, then you should include an event loop fixture with same scope
2) Client & Server:
  * `await self.writer.drain()`' is need to assure data is sent
  * EOF case considered when receiving None
  * `close()` added

Other changes to simplify the example:
* encode/decode instead of pickle
* unused code removed

Note:
Tested using start_server & open_connection (instead of start_unix_server & open_unix_connection)